### PR TITLE
Update README.md: Decrease timeout of `close` function in shadcn integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ const { child, ...modal } = useModal({ removeOnClose: false });
 function close() {
     modal.close();
 
-    setTimeout(() => modal.remove(), 1000);
+    setTimeout(() => modal.remove(), 300);
 }
 </script>
 ```


### PR DESCRIPTION
Decreased timeout of removing modal when closing shadcn Dialog. Not 100% sure but I think the closing animation takes by default 150ms. With 1000ms timeout it's easy to have a situation where modal is closed and re-opened within that 1 second which causes weird flickering. 300ms allows the closing animation to play out but user rarely is fast enough to close & re-open modal within that timeframe.